### PR TITLE
Fix up some minor errors and a missing item in rd.conf

### DIFF
--- a/rd.conf
+++ b/rd.conf
@@ -2469,7 +2469,7 @@ explicitly include.
 00840015 Charger ID,SV,
 00840016 Power Converter,CP,
 00840017 Power Converter ID,SV,
-00840018 Outlet System,CP
+00840018 Outlet System,CP,
 00840019 Outlet System ID,SV,
 0084001A Input,CP,
 0084001B Input ID,SV,
@@ -2482,6 +2482,7 @@ explicitly include.
 00840022 Gang,CLCP,
 00840023 Gang ID,SV,
 00840024 Power Summary,CLCP,
+00840025 Power Summary ID,SV,
 00840030 Voltage,DV,
 00840031 Current,DV,
 00840032 Frequency,DV,
@@ -2535,7 +2536,7 @@ explicitly include.
 
 0085 Battery System Page,BAT_
 00850000 Undefined 
-00850001 SMB Battery Mode CL,
+00850001 SMB Battery Mode,CL,
 00850002 SMB Battery Status,CL,
 00850003 SMB Alarm Warning,CL,
 00850004 SMB Charger Mode,CL,


### PR DESCRIPTION
In the power device page, the power summary ID (00840025) was missing.
In the battery system page, there was a missing comma in the SMB battery mode (00850001) definition.
For consistency with other entries added trailing comma in outlet system (00840018).