### PR TITLE
fix C header output for data field length 4

### DIFF
--- a/rd.rex
+++ b/rd.rex
@@ -1740,8 +1740,8 @@ emitDecode: procedure expose g. o. f.
         sChunk = sChunk '0x'xByte','
       end
       if xValue = '' 
-      then sDecode = left(sChunk,30) '//'left('',g.0INDENT) left('('sType')',8) left(sTag,18) sDescription
-      else sDecode = left(sChunk,30) '//'left('',g.0INDENT) left('('sType')',8) left(sTag,18) '0x'xValue sDescription
+      then sDecode = left(sChunk,31) '//'left('',g.0INDENT) left('('sType')',8) left(sTag,18) sDescription
+      else sDecode = left(sChunk,31) '//'left('',g.0INDENT) left('('sType')',8) left(sTag,18) '0x'xValue sDescription
     end
     otherwise do
       if xValue = '' 


### PR DESCRIPTION
codes with data length 4 generate invalid C headers by swallowing up the last comma

broken output:
``0x27, 0xFF, 0xFF, 0x00, 0x00 //     (GLOBAL) LOGICAL_MAXIMUM    0x0000FFFF (65535)``

fixed output:
``0x27, 0xFF, 0xFF, 0x00, 0x00, //     (GLOBAL) LOGICAL_MAXIMUM    0x0000FFFF (65535)``